### PR TITLE
fix: install.sh venv detection, Windows path support, and install dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Print a helpful message if something goes wrong
+trap 'echo -e "\n\033[0;31m✗ Installation failed at line $LINENO. See error above.\033[0m"' ERR
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -14,7 +17,9 @@ NC='\033[0m' # No Color
 
 # Default values
 INSTALL_METHOD=""
-INSTALL_DIR="$HOME/lmstudio-mcp"
+# Default to current directory rather than $HOME so tools like Pinokio
+# that invoke the script from a specific working directory install in place.
+INSTALL_DIR="$(pwd)"
 PYTHON_CMD="python3"
 VENV_NAME="venv"
 
@@ -41,9 +46,70 @@ print_info() {
     echo -e "${BLUE}ℹ $1${NC}"
 }
 
+# ---------------------------------------------------------------------------
+# Detect the activate script path for the current or a named venv.
+# On Linux/macOS venvs use bin/activate; on Windows (Git Bash / MSYS2) they
+# use Scripts/activate.  Some tools (virtualenv, conda-based wrappers, etc.)
+# may place it elsewhere, so we search rather than hard-code.
+# Usage: get_activate_path [venv_dir]   (defaults to $VENV_NAME)
+# ---------------------------------------------------------------------------
+get_activate_path() {
+    local venv_dir="${1:-$VENV_NAME}"
+    for candidate in \
+        "$venv_dir/bin/activate" \
+        "$venv_dir/Scripts/activate" \
+        "$venv_dir/scripts/activate"; do
+        if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Check whether we are already inside an active virtual environment.
+# Covers: venv, virtualenv, conda, pipenv, poetry, etc.
+# ---------------------------------------------------------------------------
+already_in_venv() {
+    # $VIRTUAL_ENV is set by venv / virtualenv activate scripts and most wrappers
+    if [ -n "$VIRTUAL_ENV" ]; then
+        return 0
+    fi
+    # $CONDA_DEFAULT_ENV covers conda environments
+    if [ -n "$CONDA_DEFAULT_ENV" ] && [ "$CONDA_DEFAULT_ENV" != "base" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Find an existing venv under the given directory by looking for an activate
+# script in common locations / sub-directories.
+# Echoes the activate path if found, returns 1 otherwise.
+# ---------------------------------------------------------------------------
+find_existing_venv() {
+    local search_dir="${1:-.}"
+    # Check common venv directory names
+    for name in venv .venv env .env virtualenv; do
+        local candidate
+        if candidate=$(get_activate_path "$search_dir/$name" 2>/dev/null); then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    # Also check if the search_dir itself is a venv root
+    local candidate
+    if candidate=$(get_activate_path "$search_dir" 2>/dev/null); then
+        echo "$candidate"
+        return 0
+    fi
+    return 1
+}
+
 check_requirements() {
     print_info "Checking system requirements..."
-    
+
     # Check Python
     if ! command -v $PYTHON_CMD &> /dev/null; then
         if command -v python &> /dev/null; then
@@ -53,22 +119,23 @@ check_requirements() {
             exit 1
         fi
     fi
-    
+
     # Check Python version
     if ! $PYTHON_CMD -c "import sys; exit(0 if sys.version_info >= (3, 7) else 1)"; then
-        print_error "Python 3.7+ is required. Found: $PYTHON_VERSION"
+        print_error "Python 3.7+ is required."
         exit 1
     fi
-    
+
+    PYTHON_VERSION=$($PYTHON_CMD -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
     print_success "Python $PYTHON_VERSION found"
-    
+
     # Check Git
     if ! command -v git &> /dev/null; then
         print_error "Git is required but not found"
         exit 1
     fi
     print_success "Git found"
-    
+
     # Check Docker (optional)
     if command -v docker &> /dev/null; then
         print_success "Docker found"
@@ -89,7 +156,7 @@ show_menu() {
     echo "5) Exit"
     echo ""
     read -p "Enter your choice (1-5): " choice
-    
+
     case $choice in
         1) INSTALL_METHOD="local" ;;
         2) INSTALL_METHOD="docker" ;;
@@ -100,14 +167,57 @@ show_menu() {
     esac
 }
 
+# ---------------------------------------------------------------------------
+# Setup virtual environment — shared by install_local and install_dev.
+# Honours any already-active venv and searches for existing ones before
+# creating a new one.  Works on Linux, macOS, and Windows (Git Bash/MSYS2).
+# ---------------------------------------------------------------------------
+setup_venv() {
+    local install_dir="${1:-.}"
+
+    if already_in_venv; then
+        print_info "Already inside a virtual environment (${VIRTUAL_ENV:-$CONDA_DEFAULT_ENV}) — skipping venv creation."
+        if ! command -v pip &> /dev/null; then
+            print_warning "pip not found in the active venv. You may need to install it manually."
+        fi
+        ACTIVATE_PATH=""   # signal that activation is not needed
+        return 0
+    fi
+
+    # Search for an existing venv inside the install directory
+    local existing
+    if existing=$(find_existing_venv "$install_dir"); then
+        print_info "Found existing virtual environment at: $existing"
+        print_info "Activating existing venv..."
+        # shellcheck disable=SC1090
+        source "$existing"
+        ACTIVATE_PATH="$existing"
+        return 0
+    fi
+
+    # No existing venv found — create one
+    print_info "Creating virtual environment..."
+    $PYTHON_CMD -m venv "$install_dir/$VENV_NAME"
+
+    local activate_path
+    if activate_path=$(get_activate_path "$install_dir/$VENV_NAME"); then
+        print_info "Activating virtual environment..."
+        # shellcheck disable=SC1090
+        source "$activate_path"
+        ACTIVATE_PATH="$activate_path"
+    else
+        print_error "Could not find activate script after creating venv. Your platform may not be supported."
+        exit 1
+    fi
+}
+
 install_local() {
     print_info "Installing LMStudio-MCP locally..."
-    
-    # Create installation directory
+
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
-    
-    # Clone repository
+
+    # Clone repository (skip if already cloned)
     if [ -d ".git" ]; then
         print_info "Repository exists, pulling latest changes..."
         git pull
@@ -115,28 +225,37 @@ install_local() {
         print_info "Cloning repository..."
         git clone https://github.com/infinitimeless/LMStudio-MCP.git .
     fi
-    
-    # Create virtual environment
-    print_info "Creating virtual environment..."
-    $PYTHON_CMD -m venv $VENV_NAME
-    
-    # Activate virtual environment
-    source $VENV_NAME/bin/activate
-    
-    # Install dependencies
+
+    setup_venv "$INSTALL_DIR"
+
     print_info "Installing dependencies..."
     pip install --upgrade pip
     pip install -r requirements.txt
-    
-    # Create startup script
-    cat > start_lmstudio_mcp.sh << 'EOF'
+
+    # Generate a startup script using the detected (or relative) activate path.
+    local rel_activate
+    if [ -n "$ACTIVATE_PATH" ]; then
+        rel_activate="${ACTIVATE_PATH#$INSTALL_DIR/}"
+    else
+        rel_activate=""
+    fi
+
+    if [ -n "$rel_activate" ]; then
+        cat > start_lmstudio_mcp.sh << EOF
+#!/bin/bash
+cd "\$(dirname "\$0")"
+source "$rel_activate"
+python lmstudio_bridge.py "\$@"
+EOF
+    else
+        cat > start_lmstudio_mcp.sh << 'EOF'
 #!/bin/bash
 cd "$(dirname "$0")"
-source venv/bin/activate
 python lmstudio_bridge.py "$@"
 EOF
+    fi
     chmod +x start_lmstudio_mcp.sh
-    
+
     print_success "Local installation completed!"
     print_info "Installation directory: $INSTALL_DIR"
     print_info "To start: cd $INSTALL_DIR && ./start_lmstudio_mcp.sh"
@@ -147,28 +266,25 @@ install_docker() {
         print_error "Docker is not available"
         exit 1
     fi
-    
+
     print_info "Setting up Docker deployment..."
-    
+
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
-    
-    # Download Docker files
+
     print_info "Downloading Docker configuration..."
     curl -s https://raw.githubusercontent.com/infinitimeless/LMStudio-MCP/main/Dockerfile -o Dockerfile
     curl -s https://raw.githubusercontent.com/infinitimeless/LMStudio-MCP/main/.dockerignore -o .dockerignore
-    
-    # Build image
+
     print_info "Building Docker image..."
     docker build -t lmstudio-mcp .
-    
-    # Create run script
+
     cat > run_docker.sh << 'EOF'
 #!/bin/bash
 docker run -it --rm --network host --name lmstudio-mcp-server lmstudio-mcp
 EOF
     chmod +x run_docker.sh
-    
+
     print_success "Docker installation completed!"
     print_info "To start: cd $INSTALL_DIR && ./run_docker.sh"
 }
@@ -178,42 +294,40 @@ install_compose() {
         print_error "Docker is not available"
         exit 1
     fi
-    
+
     if ! command -v docker-compose &> /dev/null; then
         print_error "Docker Compose is required but not found"
         exit 1
     fi
-    
+
     print_info "Setting up Docker Compose deployment..."
-    
+
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
-    
-    # Download compose files
+
     print_info "Downloading Docker Compose configuration..."
     curl -s https://raw.githubusercontent.com/infinitimeless/LMStudio-MCP/main/docker-compose.yml -o docker-compose.yml
     curl -s https://raw.githubusercontent.com/infinitimeless/LMStudio-MCP/main/Dockerfile -o Dockerfile
     curl -s https://raw.githubusercontent.com/infinitimeless/LMStudio-MCP/main/.dockerignore -o .dockerignore
-    
-    # Create management scripts
+
     cat > start.sh << 'EOF'
 #!/bin/bash
 docker-compose up -d
 EOF
     chmod +x start.sh
-    
+
     cat > stop.sh << 'EOF'
 #!/bin/bash
 docker-compose down
 EOF
     chmod +x stop.sh
-    
+
     cat > logs.sh << 'EOF'
 #!/bin/bash
 docker-compose logs -f lmstudio-mcp
 EOF
     chmod +x logs.sh
-    
+
     print_success "Docker Compose installation completed!"
     print_info "Commands:"
     print_info "  Start: cd $INSTALL_DIR && ./start.sh"
@@ -223,12 +337,10 @@ EOF
 
 install_dev() {
     print_info "Setting up development environment..."
-    
-    # Create installation directory
+
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
-    
-    # Clone repository
+
     if [ -d ".git" ]; then
         print_info "Repository exists, pulling latest changes..."
         git pull
@@ -236,28 +348,29 @@ install_dev() {
         print_info "Cloning repository..."
         git clone https://github.com/infinitimeless/LMStudio-MCP.git .
     fi
-    
-    # Create virtual environment
-    print_info "Creating virtual environment..."
-    $PYTHON_CMD -m venv $VENV_NAME
-    
-    # Activate virtual environment
-    source $VENV_NAME/bin/activate
-    
-    # Install dependencies including dev tools
+
+    setup_venv "$INSTALL_DIR"
+
     print_info "Installing dependencies..."
     pip install --upgrade pip
     pip install -r requirements.txt
     pip install -e .
-    
-    # Install development dependencies
+
+    print_info "Installing development dependencies..."
     pip install pytest pytest-cov black flake8 mypy
-    
-    # Create development scripts
-    cat > dev_setup.sh << 'EOF'
+
+    local rel_activate
+    if [ -n "$ACTIVATE_PATH" ]; then
+        rel_activate="${ACTIVATE_PATH#$INSTALL_DIR/}"
+    else
+        rel_activate=""
+    fi
+
+    if [ -n "$rel_activate" ]; then
+        cat > dev_setup.sh << EOF
 #!/bin/bash
-cd "$(dirname "$0")"
-source venv/bin/activate
+cd "\$(dirname "\$0")"
+source "$rel_activate"
 echo "Development environment activated"
 echo "Available commands:"
 echo "  python lmstudio_bridge.py  - Run the bridge"
@@ -265,8 +378,20 @@ echo "  pytest                     - Run tests"
 echo "  black .                    - Format code"
 echo "  flake8 .                   - Lint code"
 EOF
+    else
+        cat > dev_setup.sh << 'EOF'
+#!/bin/bash
+cd "$(dirname "$0")"
+echo "Development environment ready (using active venv)"
+echo "Available commands:"
+echo "  python lmstudio_bridge.py  - Run the bridge"
+echo "  pytest                     - Run tests"
+echo "  black .                    - Format code"
+echo "  flake8 .                   - Lint code"
+EOF
+    fi
     chmod +x dev_setup.sh
-    
+
     print_success "Development environment setup completed!"
     print_info "Installation directory: $INSTALL_DIR"
     print_info "To activate: cd $INSTALL_DIR && source dev_setup.sh"
@@ -274,7 +399,7 @@ EOF
 
 create_mcp_config() {
     print_info "Creating MCP configuration example..."
-    
+
     cat > mcp_config_example.json << EOF
 {
   "lmstudio-mcp": {
@@ -285,21 +410,27 @@ create_mcp_config() {
   }
 }
 EOF
-    
+
     if [ "$INSTALL_METHOD" = "local" ]; then
+        local activate_snippet
+        if [ -n "$ACTIVATE_PATH" ]; then
+            activate_snippet="cd $INSTALL_DIR && source $ACTIVATE_PATH && python lmstudio_bridge.py"
+        else
+            activate_snippet="cd $INSTALL_DIR && python lmstudio_bridge.py"
+        fi
         cat > mcp_config_local.json << EOF
 {
   "lmstudio-mcp-local": {
     "command": "/bin/bash",
     "args": [
       "-c",
-      "cd $INSTALL_DIR && source venv/bin/activate && python lmstudio_bridge.py"
+      "$activate_snippet"
     ]
   }
 }
 EOF
     fi
-    
+
     if [ "$INSTALL_METHOD" = "docker" ]; then
         cat > mcp_config_docker.json << EOF
 {
@@ -316,25 +447,25 @@ EOF
 }
 EOF
     fi
-    
+
     print_success "MCP configuration examples created"
 }
 
 main() {
     print_header
-    
+
     check_requirements
     show_menu
-    
+
     case $INSTALL_METHOD in
         "local") install_local ;;
         "docker") install_docker ;;
         "compose") install_compose ;;
         "dev") install_dev ;;
     esac
-    
+
     create_mcp_config
-    
+
     echo ""
     print_success "Installation completed successfully!"
     print_info "Next steps:"


### PR DESCRIPTION
## Problem

Reported by a user running the install script inside Pinokio on Windows with a pre-existing venv.

Three bugs were present:

1. **Install directory defaulted to `$HOME`** — `INSTALL_DIR="$HOME/lmstudio-mcp"` caused the script to break out of the user's working directory and install in their Windows home folder instead of where Pinokio (or any other launcher) invoked the script from.

2. **No detection of an already-active venv** — The script unconditionally created a new venv even if `$VIRTUAL_ENV` was already set (i.e. the user was already inside one). This broke Pinokio environments and any other tool that pre-activates a venv before running the script.

3. **Hardcoded `bin/activate` path breaks on Windows** — On Windows (Git Bash / MSYS2), the activate script lives at `Scripts/activate`, not `bin/activate`. The generated `start_lmstudio_mcp.sh` had the same hardcoded path.

## Fix

- `INSTALL_DIR` now defaults to `$(pwd)` — install happens where the script is run from.
- `already_in_venv()` checks `$VIRTUAL_ENV` and `$CONDA_DEFAULT_ENV` before creating anything.
- `find_existing_venv()` searches common venv directory names (`venv`, `.venv`, `env`, etc.) before creating a new one.
- `get_activate_path()` tries `bin/activate`, `Scripts/activate`, and `scripts/activate` in order — works on Linux, macOS, and Windows.
- Generated `start_lmstudio_mcp.sh` and `dev_setup.sh` now use the detected path rather than the hardcoded `venv/bin/activate`.
- Added a `trap` on `ERR` so failures print the line number instead of silently dying.

## Testing

Verified the following scenarios are handled correctly:
- Fresh install on Linux/macOS (creates `venv/bin/activate`)
- Fresh install on Windows Git Bash (creates `venv/Scripts/activate`)
- Running inside an existing venv — skips creation entirely
- Running from a Pinokio-managed directory — installs in place, not `$HOME`
- Existing venv present in directory — reuses it without recreating